### PR TITLE
Documentation to install catharge

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ### How to build
 
 - Clone or download a copy of the repository
-- If you don't already have it, get Carthage
+- If you don't already have it, get Carthage using `brew install carthage` or any of the other methods listed [here](https://github.com/Carthage/Carthage#installing-carthage).
 - In terminal, `cd` into your copy and run `$ carthage bootstrap --cache-builds --platform macos`
 - Open `Boop/Boop.xcodeproj`
 - Press play


### PR DESCRIPTION
Just thought of this package when I was about to google for json validatior! For beginner users (like me) who don't know what catharge is, I think it's useful to add a direct installation command in the README.