### PR TITLE
add support for both light and dark appearances

### DIFF
--- a/Boop/Boop/AppDelegate.swift
+++ b/Boop/Boop/AppDelegate.swift
@@ -19,9 +19,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @IBOutlet weak var scriptManager: ScriptManager!
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
-        // Disable light mode because why in heck would you want that???
-        NSApp.appearance = NSAppearance(named: .darkAqua)
-        
         NSWindow.allowsAutomaticWindowTabbing = false
     }
 

--- a/Boop/Boop/Assets.xcassets/EditorColors/Contents.json
+++ b/Boop/Boop/Assets.xcassets/EditorColors/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Boop/Boop/Assets.xcassets/EditorColors/blueButDarker.colorset/Contents.json
+++ b/Boop/Boop/Assets.xcassets/EditorColors/blueButDarker.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.717",
+          "green" : "0.416",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Boop/Boop/Assets.xcassets/EditorColors/bluish.colorset/Contents.json
+++ b/Boop/Boop/Assets.xcassets/EditorColors/bluish.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.851",
+          "green" : "0.755",
+          "red" : "0.425"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFE",
+          "green" : "0xE2",
+          "red" : "0x7F"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Boop/Boop/Assets.xcassets/EditorColors/commentGrey.colorset/Contents.json
+++ b/Boop/Boop/Assets.xcassets/EditorColors/commentGrey.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.700",
+          "green" : "0.601",
+          "red" : "0.577"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.852",
+          "green" : "0.732",
+          "red" : "0.702"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Boop/Boop/Assets.xcassets/EditorColors/cyanish.colorset/Contents.json
+++ b/Boop/Boop/Assets.xcassets/EditorColors/cyanish.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.586",
+          "green" : "0.699",
+          "red" : "0.119"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.799",
+          "green" : "0.952",
+          "red" : "0.162"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Boop/Boop/Assets.xcassets/EditorColors/greenButDarker.colorset/Contents.json
+++ b/Boop/Boop/Assets.xcassets/EditorColors/greenButDarker.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.699",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Boop/Boop/Assets.xcassets/EditorColors/greenish.colorset/Contents.json
+++ b/Boop/Boop/Assets.xcassets/EditorColors/greenish.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.684",
+          "red" : "0.410"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "1.000",
+          "red" : "0.606"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Boop/Boop/Assets.xcassets/EditorColors/orangeish.colorset/Contents.json
+++ b/Boop/Boop/Assets.xcassets/EditorColors/orangeish.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.239",
+          "green" : "0.559",
+          "red" : "0.800"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.299",
+          "green" : "0.699",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Boop/Boop/Assets.xcassets/EditorColors/purpleButDarker.colorset/Contents.json
+++ b/Boop/Boop/Assets.xcassets/EditorColors/purpleButDarker.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.464",
+          "green" : "0.000",
+          "red" : "0.464"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Boop/Boop/Assets.xcassets/EditorColors/redButDarker.colorset/Contents.json
+++ b/Boop/Boop/Assets.xcassets/EditorColors/redButDarker.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.264",
+          "green" : "0.093",
+          "red" : "0.724"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Boop/Boop/Assets.xcassets/EditorColors/redey.colorset/Contents.json
+++ b/Boop/Boop/Assets.xcassets/EditorColors/redey.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x63",
+          "green" : "0x3C",
+          "red" : "0xCB"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.488",
+          "green" : "0.299",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Boop/Boop/Assets.xcassets/EditorColors/yellowishy.colorset/Contents.json
+++ b/Boop/Boop/Assets.xcassets/EditorColors/yellowishy.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.254",
+          "green" : "0.850",
+          "red" : "0.841"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.299",
+          "green" : "1.000",
+          "red" : "0.990"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Boop/Boop/Controllers/MainViewController.swift
+++ b/Boop/Boop/Controllers/MainViewController.swift
@@ -24,12 +24,8 @@ class MainViewController: NSViewController {
         
         #endif
         
-        
         editorView.delegate = self
         editorView.theme = DefaultTheme()
-        
-        editorView.contentTextView.selectedTextAttributes = [.backgroundColor:NSColor(red:0.19, green:0.44, blue:0.71, alpha:1.0), .foregroundColor: NSColor.white]
-        
     }
     @IBAction func openHelp(_ sender: Any) {
         guard let url = URL(string: "https://github.com/IvanMathy/Boop/blob/master/Boop/Documentation/Readme.md") else {

--- a/Boop/Boop/Editor/Themes/Colors.swift
+++ b/Boop/Boop/Editor/Themes/Colors.swift
@@ -9,17 +9,18 @@
 import Cocoa
 
 struct Colors {
-    static let redey: NSColor = #colorLiteral(red: 1, green: 0.2980392157, blue: 0.4862745098, alpha: 1) // #ff4c7c
-    static let bluish: NSColor = #colorLiteral(red: 0.5, green: 0.8870540044, blue: 1, alpha: 1) // #3586FF
-    static let cyanish: NSColor = #colorLiteral(red: 0.1595847315, green: 0.951053901, blue: 0.7986315017, alpha: 1) // #4cffb2
-    static let greenish: NSColor = #colorLiteral(red: 0.6049238592, green: 1, blue: 0, alpha: 1) // #32FF47
-    static let orangeish: NSColor = #colorLiteral(red: 1, green: 0.6980392157, blue: 0.2980392157, alpha: 1) // #ffb24c
-    static let yellowishy: NSColor = #colorLiteral(red: 0.9882352941, green: 1, blue: 0.2980392157, alpha: 1) // #fcff4c
-    static let commentGrey: NSColor = #colorLiteral(red: 0.7008966023, green: 0.7301803691, blue: 0.8538076556, alpha: 1) // #9BCCE3
-    static let redButDarker: NSColor = #colorLiteral(red: 0.7254901961, green: 0.09411764706, blue: 0.262745098, alpha: 1) // #B91843
-    static let blueButDarker: NSColor = #colorLiteral(red: 0, green: 0.4156862745, blue: 0.7176470588, alpha: 1) // #006AB7
-    static let greenButDarker: NSColor = #colorLiteral(red: 0, green: 0.6980392157, blue: 0, alpha: 1) // #00B200
-    static let purpleButDarker: NSColor = #colorLiteral(red: 0.462745098, green: 0, blue: 0.462745098, alpha: 1) // #760076
+//    static let redey: NSColor = #colorLiteral(red: 1, green: 0.2980392157, blue: 0.4862745098, alpha: 1) // #ff4c7c
+    static let redey: NSColor = NSColor(named: "redey")!
+    static let bluish: NSColor = NSColor(named: "bluish")!
+    static let cyanish: NSColor = NSColor(named: "cyanish")!
+    static let greenish: NSColor = NSColor(named: "greenish")!
+    static let orangeish: NSColor = NSColor(named: "orangeish")!
+    static let yellowishy: NSColor = NSColor(named: "yellowishy")!
+    static let commentGrey: NSColor = NSColor(named: "commentGrey")!
+    static let redButDarker: NSColor = NSColor(named: "redButDarker")!
+    static let blueButDarker: NSColor = NSColor(named: "blueButDarker")!
+    static let greenButDarker: NSColor = NSColor(named: "greenButDarker")!
+    static let purpleButDarker: NSColor = NSColor(named: "purpleButDarker")!
 }
 
 

--- a/Boop/Boop/Editor/Themes/DefaultTheme.swift
+++ b/Boop/Boop/Editor/Themes/DefaultTheme.swift
@@ -14,19 +14,19 @@ class DefaultTheme: SyntaxColorTheme {
     var tabWidth: Int = 4
     
     let gutterStyle: GutterStyle = GutterStyle(
-        backgroundColor: Color(red: 22/255.0, green: 22/255, blue: 22/255, alpha: 1.0),
-        separatorColor: Color(red: 15/255.0, green: 15/255, blue: 15/255, alpha: 1.0),
+        backgroundColor: Color.textBackgroundColor,
+        separatorColor: Color.separatorColor,
         minimumWidth: 40)
-    
+
     var font: Font = NSFont(name: "SFMono-Regular", size: 15) ?? Font(name: "Menlo", size: 15)!
     
     let lineNumbersStyle: LineNumbersStyle?
     
-    var backgroundColor: Color = Color(red: 31/255.0, green: 31/255, blue: 31/255, alpha: 1.0)
-    
+    var backgroundColor: Color = Color.textBackgroundColor
+
     
     init() {
-        lineNumbersStyle = LineNumbersStyle(font: font, textColor: Color(red: 100/255, green: 100/255, blue: 100/255, alpha: 1.0))
+        lineNumbersStyle = LineNumbersStyle(font: font, textColor: Color.tertiaryLabelColor)
     }
     
     func globalAttributes() -> [NSAttributedString.Key: Any] {
@@ -34,7 +34,7 @@ class DefaultTheme: SyntaxColorTheme {
         var attributes = [NSAttributedString.Key: Any]()
         
         attributes[.font] = self.font
-        attributes[.foregroundColor] = NSColor.white
+        attributes[.foregroundColor] = NSColor.textColor
         
         return attributes
     }

--- a/Boop/Boop/Views/OverlayView.swift
+++ b/Boop/Boop/Views/OverlayView.swift
@@ -13,7 +13,7 @@ class OverlayView: NSView {
     required init?(coder decoder: NSCoder) {
         super.init(coder: decoder)
         self.wantsLayer = true
-        self.layer?.backgroundColor = NSColor(calibratedWhite: 0.05, alpha: 1).cgColor
+        
         self.animator().isHidden = true
         self.alphaValue = 0;
     }

--- a/Boop/Boop/Views/PopoverView.swift
+++ b/Boop/Boop/Views/PopoverView.swift
@@ -15,12 +15,15 @@ class PopoverView: NSView {
         
         // UI set up
         self.wantsLayer = true
-        self.layer?.cornerRadius = 5.0
+        self.layer?.cornerRadius = 8.0
         self.layer?.masksToBounds = true
-        self.layer?.backgroundColor = NSColor(calibratedWhite: 0.05, alpha: 1).cgColor
+        
+        self.layer?.borderWidth = 1.0
         
         let dropShadow = NSShadow()
-        dropShadow.shadowColor = NSColor(calibratedWhite: 0, alpha: 1)
+        
+        setLayerColors()
+        
         dropShadow.shadowOffset = NSMakeSize(0, -10.0)
         dropShadow.shadowBlurRadius = 10.0
         
@@ -40,7 +43,12 @@ class PopoverView: NSView {
         self.animator().isHidden = true;
     }
     
+    override func updateLayer() {
+        setLayerColors()
+    }
     
-    
-    
+    func setLayerColors() {
+        self.layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
+        self.layer?.borderColor = NSColor.separatorColor.cgColor
+    }
 }

--- a/Boop/Boop/Views/StatusView.swift
+++ b/Boop/Boop/Views/StatusView.swift
@@ -34,10 +34,6 @@ class StatusView: NSView {
         super.awakeFromNib()
         
         self.wantsLayer = true
-        
-        self.layer?.backgroundColor = NSColor.textBackgroundColor.cgColor
-        self.layer?.cornerRadius = 5
-        
     }
 
     func setStatus(_ newStatus: Status) {
@@ -121,7 +117,7 @@ class StatusView: NSView {
     
     fileprivate func updateColor(_ newStatus: Status) {
         
-        var color = NSColor.textBackgroundColor
+        var color = NSColor.textColor
         
         switch newStatus {
         case .normal, .help(_):
@@ -138,7 +134,8 @@ class StatusView: NSView {
         
         NSAnimationContext.runAnimationGroup({ (context) in
             context.duration = self.transitionLength
-            self.layer?.backgroundColor = color.cgColor
+            self.textLabel.textColor = color
         })
+
     }
 }

--- a/Boop/UI/Base.lproj/MainMenu.xib
+++ b/Boop/UI/Base.lproj/MainMenu.xib
@@ -498,7 +498,7 @@ Gw
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="335" y="390" width="480" height="360"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="900"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1057"/>
             <value key="minSize" type="size" width="480" height="360"/>
             <view key="contentView" wantsLayer="YES" id="EiT-Mj-1SZ">
                 <rect key="frame" x="0.0" y="0.0" width="480" height="360"/>
@@ -519,8 +519,8 @@ Gw
                                     <constraint firstAttribute="height" constant="30" id="4GE-bC-UdC"/>
                                 </constraints>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" focusRingType="none" placeholderString="Start typing..." id="cpq-qD-Ulg">
-                                    <font key="font" metaFont="systemLight" size="21"/>
-                                    <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <font key="font" metaFont="system" size="21"/>
+                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                                 <connections>
@@ -613,7 +613,6 @@ Gw
                                             </connections>
                                         </tableView>
                                     </subviews>
-                                    <nil key="backgroundColor"/>
                                 </clipView>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="140" id="Nja-wF-cOR"/>
@@ -659,32 +658,32 @@ Gw
                     <toolbarItem implicitItemIdentifier="C5459F48-A2E4-4A46-BA5F-7368C65F8AC9" label="Custom View" paletteLabel="Custom View" tag="-1" sizingBehavior="auto" id="mG6-GU-aNe">
                         <nil key="toolTip"/>
                         <customView key="view" misplaced="YES" id="zMi-QK-dkF" customClass="StatusView" customModule="Boop" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="14" width="200" height="20"/>
+                            <rect key="frame" x="0.0" y="14" width="300" height="24"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                             <subviews>
-                                <stackView distribution="equalCentering" orientation="horizontal" alignment="centerY" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Nlt-yx-S75">
-                                    <rect key="frame" x="4" y="0.0" width="200" height="20"/>
+                                <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Nlt-yx-S75">
+                                    <rect key="frame" x="4" y="0.0" width="292" height="25"/>
                                     <subviews>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aib-Zm-MbW">
-                                            <rect key="frame" x="26" y="3" width="148" height="15"/>
-                                            <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Press ⌘+B to get started" drawsBackground="YES" id="Sc8-Qd-kcQ">
+                                            <rect key="frame" x="0.0" y="2" width="292" height="22"/>
+                                            <textFieldCell key="cell" lineBreakMode="clipping" borderStyle="bezel" alignment="center" title="Press ⌘+B to get started" bezelStyle="round" id="Sc8-Qd-kcQ">
                                                 <font key="font" metaFont="systemLight" size="12"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="PpN-Z0-jAa" customClass="UpdateTextField" customModule="Boop" customModuleProvider="target">
-                                            <rect key="frame" x="0.0" y="6" width="69" height="14"/>
+                                            <rect key="frame" x="0.0" y="11" width="69" height="14"/>
                                             <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Learn More" drawsBackground="YES" id="o6X-4x-gie">
                                                 <font key="font" metaFont="systemMedium" size="11"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                             </textFieldCell>
                                         </textField>
                                     </subviews>
                                     <constraints>
-                                        <constraint firstAttribute="width" constant="200" id="Dev-i3-vUc"/>
-                                        <constraint firstAttribute="height" constant="20" id="UsD-XM-AIh"/>
+                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="Dev-i3-vUc"/>
+                                        <constraint firstAttribute="height" constant="25" id="UsD-XM-AIh"/>
                                     </constraints>
                                     <visibilityPriorities>
                                         <integer value="1000"/>


### PR DESCRIPTION
I know you may not be enthusiastic about it, but I really prefer to use the light appearance most of the time (my Mac is set to Auto for appearance and Dynamic for desktop).

The only colors I changed were to use system semantic colors & added alternate appearances for the theme colors. I also tweaked the status view to be a little more standard.

I understand if the changes aren't something you'd be willing to accept.

Nice work, otherwise!