### PR TITLE
Add URL params to JSON converter

### DIFF
--- a/Boop/Boop/scripts/JsonToQuery.js
+++ b/Boop/Boop/scripts/JsonToQuery.js
@@ -1,0 +1,43 @@
+/**
+	{
+		"api":1,
+		"name":"JSON to Query String",
+		"description":"Converts JSON to URL query string",
+		"author":"Ota Mares <ota@mares.one>",
+		"icon":"table",
+		"tags":"url,query,params,json,convert,encode"
+	}
+**/
+
+/**
+ * Credit goes to https://stackoverflow.com/a/1714899
+ */
+function convertToQuery(obj, prefix) {
+	let queryParts = []
+
+	for (param in obj) {
+		if (obj.hasOwnProperty(param)) {
+			let key = prefix ? prefix + "[]" : param;
+			let value = obj[param];
+
+			queryParts.push(
+				(value !== null && typeof value === "object") ?
+				convertToQuery(value, key) :
+					key + "=" + value
+			);
+		}
+	}
+
+	return queryParts.join("&");
+}
+
+function main(input)
+{
+    try {
+		input.text = convertToQuery(JSON.parse(input.text));
+    } catch (error) {
+        input.postError("Unable to convert JSON to URL params")
+        input.text = error.message
+    }
+
+}

--- a/Boop/Boop/scripts/QueryToJson.js
+++ b/Boop/Boop/scripts/QueryToJson.js
@@ -1,0 +1,42 @@
+/**
+	{
+		"api":1,
+		"name":"Query String to JSON",
+		"description":"Converts URL query string to JSON",
+		"author":"Ota Mares <ota@mares.one>",
+		"icon":"table",
+		"tags":"url,query,params,json,convert,decode"
+	}
+**/
+
+function convertToJson(urlParams) {
+
+    return urlParams
+        .replace(/\[\d?\]=/gi, '=')
+        .split('&')
+        .reduce((result, param) => {
+            var [key, value] = param.split('=');
+            value = decodeURIComponent(value || '');
+
+            if (!result.hasOwnProperty(key)) {
+                result[key] = value;
+
+                return result;
+            }
+
+            result[key] = [...[].concat(result[key]), value]
+
+            return result
+        }, {});
+}
+
+function main(input)
+{
+    try {
+        input.text = JSON.stringify(convertToJson(input.text));
+    } catch (error) {
+        input.postError("Unable to parse given string")
+        input.text = error.message
+    }
+
+}


### PR DESCRIPTION
Converts a string of URL params to JSON and vice versa.

![Screenshot_2020 06 19_at_23 18 08](https://user-images.githubusercontent.com/1375307/85180332-7a44a380-b283-11ea-9a09-caafecde4f6a.gif)


Query string used in GIF demo.
```
foo[]=example&foo[]=is_supported&bar=baz&more=params&foo[bar]=3
```

JSON result

```
{"foo":["example","is_supported"],"bar":"baz","more":"params","foo[bar]":"3"}
```

