### PR TITLE
fixed multiline error in HTML encoder

### DIFF
--- a/Boop/Boop/scripts/HTMLEncode.js
+++ b/Boop/Boop/scripts/HTMLEncode.js
@@ -182,7 +182,10 @@ var Encoder = {
 			s = this.NumericalToHTML(s);
 		}
 
-		return s;					
+		// keep linebreaks
+		s = s.replace(/&#10;/g,"\n");
+
+		return s;				
 	},
 
 	// Encodes the basic 4 characters used to malform HTML in XSS hacks

--- a/Boop/Boop/scripts/ReverseString.js
+++ b/Boop/Boop/scripts/ReverseString.js
@@ -43,7 +43,7 @@ function main(input) {
 */
 
 
-var regexSymbolWithCombiningMarks = /(<%= allExceptCombiningMarks %>)(<%= combiningMarks %>+)/g;
+var regexSymbolWithCombiningMarks = /([\0-\u02FF\u0370-\u1AAF\u1B00-\u1DBF\u1E00-\u20CF\u2100-\uD7FF\uE000-\uFE1F\uFE30-\uFFFF]|[\uD800-\uDBFF][\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF])([\u0300-\u036F\u1AB0-\u1AFF\u1DC0-\u1DFF\u20D0-\u20FF\uFE20-\uFE2F]+)/g;
 var regexSurrogatePair = /([\uD800-\uDBFF])([\uDC00-\uDFFF])/g;
 
 var reverse = function(string) {


### PR DESCRIPTION
Currently when you enter multiline HTML (as in all HTML) it replaces linebreaks with &#10;, this patch fixes that.
