### PR TITLE
Add script execution function `insert()`

### DIFF
--- a/Boop/Boop/System/Models/ScriptExecution.swift
+++ b/Boop/Boop/System/Models/ScriptExecution.swift
@@ -16,6 +16,7 @@ import JavaScriptCore
     var isSelection: Bool { get }
     func postError(_ error: String)
     func postInfo(_ info: String)
+    func insert(_ newValue: String)
 }
 
 
@@ -24,14 +25,16 @@ import JavaScriptCore
     var isSelection: Bool
     var selection: String?
     var fullText: String?
+    let insertIndex: Int?
     
     private weak var script: Script?
     
-    init(selection: String?, fullText: String, script: Script) {
+    init(selection: String?, fullText: String, script: Script, insertIndex: Int?) {
         self.isSelection = (selection != nil)
         self.selection = selection
         self.fullText = fullText
         self.script = script
+        self.insertIndex = insertIndex
     }
     
     var text: String? {
@@ -55,4 +58,14 @@ import JavaScriptCore
         self.script?.onScriptInfo(message: info)
     }
     
+    func insert(_ newValue: String) {
+        if isSelection {
+            selection = newValue
+        } else {
+            if let insertIndex = self.insertIndex, fullText != nil {
+                let point = fullText!.index(fullText!.startIndex, offsetBy: insertIndex)
+                fullText!.insert(contentsOf: newValue, at: point )
+            }
+        }
+    }
 }

--- a/Boop/Boop/System/ScriptManager.swift
+++ b/Boop/Boop/System/ScriptManager.swift
@@ -152,7 +152,8 @@ class ScriptManager: NSObject {
         
         guard let ranges = editor.contentTextView.selectedRanges as? [NSRange], ranges.reduce(0, { $0 + $1.length }) > 0 else {
             
-            let result = runScript(script, fullText: fullText)
+            let insertPosition = (editor.contentTextView.selectedRanges.first as! NSRange).location
+            let result = runScript(script, fullText: fullText, insertIndex: insertPosition)
             // No selection, run on full text
             
             let unicodeSafeFullTextLength = editor.contentTextView.textStorage?.length ?? fullText.count
@@ -222,8 +223,8 @@ class ScriptManager: NSObject {
         textView.didChangeText()
     }
     
-    func runScript(_ script: Script, selection: String? = nil, fullText: String) -> String {
-        let scriptExecution = ScriptExecution(selection: selection, fullText: fullText, script: script)
+    func runScript(_ script: Script, selection: String? = nil, fullText: String, insertIndex: Int? = nil) -> String {
+        let scriptExecution = ScriptExecution(selection: selection, fullText: fullText, script: script, insertIndex: insertIndex)
         
         script.run(with: scriptExecution)
         

--- a/Boop/Documentation/CustomScripts.md
+++ b/Boop/Documentation/CustomScripts.md
@@ -66,10 +66,11 @@ Script executions are not exactly full Javascript objects, instead they're a pro
 
 #### Properties
 
-The script execution object has three properties to deal with text: `text`, `fullText`, and `selection`.
+The script execution object has three properties and functions to deal with text: `text`, `fullText`, `selection`, and `insert()`.
 * `fullText` will contain or set the entire string from the Boop editor, regardless of whether a selection is made or not.
 * `selection` will contain or set the currently selected text, one at a time if more that one selection exists (see below).
 * `text`  will behave like `selection` if there is one or more selected piece of text, otherwise it will behave like `fullText`. 
+* `insert()` takes in a single string argument, and inserts it at the caret position. If there is a selected piece of text, it will be replaced.
 
 ```js
 


### PR DESCRIPTION
Fixes issue #75 

Added a function to the script execution context to insert text into the document. It inserts the text into the current caret position, unless there is a selection, in which case the selection is replaced.

My first contribution here, comments and edits very welcome!