### PR TITLE
Enable mouse interactions

### DIFF
--- a/Boop/Boop/Controllers/PopoverViewController.swift
+++ b/Boop/Boop/Controllers/PopoverViewController.swift
@@ -31,6 +31,11 @@ class PopoverViewController: NSViewController {
 
         // Double-click script selection
         tableView.doubleAction = #selector(runSelectedScript)
+
+        // Dismiss popover on background view click
+        overlayView.onMouseDown = { [weak self] in
+            self?.hide()
+        }
         
         setupKeyHandlers()
     }

--- a/Boop/Boop/Controllers/PopoverViewController.swift
+++ b/Boop/Boop/Controllers/PopoverViewController.swift
@@ -68,7 +68,7 @@ class PopoverViewController: NSViewController {
                     return theEvent
                 }
 
-                self.runScriptAgain()
+                self.runSelectedScript()
                 
                 didSomething = true
             }

--- a/Boop/Boop/Controllers/PopoverViewController.swift
+++ b/Boop/Boop/Controllers/PopoverViewController.swift
@@ -28,6 +28,9 @@ class PopoverViewController: NSViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        // Double-click script selection
+        tableView.doubleAction = #selector(runSelectedScript)
         
         setupKeyHandlers()
     }
@@ -55,18 +58,12 @@ class PopoverViewController: NSViewController {
             }
             
             if theEvent.keyCode == 36 && self.enabled { // ENTER
-                
-                guard let script = self.tableViewController.selectedScript else {
-                    return theEvent // Return event to beep
+
+                guard self.tableViewController.selectedScript != nil else {
+                    return theEvent
                 }
-                
-                
-                // Let's dismiss the popover
-                self.hide()
-                
-                // Run the script afterwards in case we need to show a status
-                self.scriptManager.runScript(script, into: self.editorView)
-                
+
+                self.runScriptAgain()
                 
                 didSomething = true
             }
@@ -141,6 +138,18 @@ class PopoverViewController: NSViewController {
     
     func runScriptAgain() {
         self.scriptManager.runScriptAgain(editor: self.editorView)
+    }
+
+    @objc private func runSelectedScript() {
+        guard let script = tableViewController.selectedScript else {
+            return
+        }
+
+        // Let's dismiss the popover
+        hide()
+
+        // Run the script afterwards in case we need to show a status
+        scriptManager.runScript(script, into: editorView)
     }
     
 }

--- a/Boop/Boop/Views/OverlayView.swift
+++ b/Boop/Boop/Views/OverlayView.swift
@@ -10,6 +10,8 @@ import Cocoa
 
 class OverlayView: NSView {
 
+    var onMouseDown: (() -> Void)?
+
     required init?(coder decoder: NSCoder) {
         super.init(coder: decoder)
         self.wantsLayer = true
@@ -32,7 +34,7 @@ class OverlayView: NSView {
     }
     
     override func mouseDown(with event: NSEvent) {
-        return
+        onMouseDown?()
     }
     
 }


### PR DESCRIPTION
Hey Ivan! 👋

I've been playing with Boop time to time and found it very annoying that it's not possible to select script or close input popover using mouse. It's also mentioned in #124, so it might help other folks too.

The mentioned issue only covers script selection part of this PR, but it plays so nicely along with popup dismissal that I implemented it together.


Keep up the good work 👍 