### PR TITLE
Add a guide to using node modules in boop

### DIFF
--- a/Boop/Documentation/ConvertingNodeModules.md
+++ b/Boop/Documentation/ConvertingNodeModules.md
@@ -1,0 +1,38 @@
+# Converting Node Modules
+
+For more complex scripts it can be nice to leverage packages from NPM.
+However, most modules are not compatible with Boop. Luckily any script
+that can be in a browser can work with Boop!
+
+## Crafting Your Script
+
+First write your script like any normal Boop Script
+ except declare your main in the `global` namespace and dont add
+ the declarative json document yet.
+
+```
+const curlconverter = require('curlconverter');
+
+global.main = function(state) {
+    try {
+        state.text = curlconverter.toPython(state.text);
+    } catch (error) {
+        state.postError("Failed to Convert");
+    }
+}
+```
+
+Then use [Browserify](http://browserify.org/) to bundle 
+the script.
+
+`browserify curlToPython_orig.js -o curlToPythonBundle.js`
+
+Boop is not a browser. That means you need to add a window var. Just add this line
+to the top of the script.
+```
+const window = this;
+```
+ 
+Finally, add the declarative JSON document
+(as described in [Custom Scripts](CustomScripts.md)) to the top, and you are done!
+

--- a/Boop/Documentation/Readme.md
+++ b/Boop/Documentation/Readme.md
@@ -7,6 +7,7 @@ Hey there! Thanks for trying out Boop. This documentation should hopefully help 
  - [Custom Scripts](CustomScripts.md)
  - [Modules](Modules.md)
  - [Debugging Scripts](Debugging.md)
+ - [Converting Node Modules](ConvertingNodeModules.md)
 
 ## Getting Boop
 


### PR DESCRIPTION
I am not sure if this is the kind of thing you want or not. However, I thought I would share in case you do.

I love Boop (thanks for this btw). However there is one script I really wanted https://curl.trillworks.com/

However, since Boop is written in Swift es6 modules are a no go. So I spent an afternoon hacking around and eventually landed on this trick.

![woot](https://user-images.githubusercontent.com/1521093/91674475-cffcbe00-eb06-11ea-83b7-e10c520909e5.gif)
