### PR TITLE
add a script for replacing Smart Quotes

### DIFF
--- a/Scripts/replaceSmartQuotes.js
+++ b/Scripts/replaceSmartQuotes.js
@@ -1,0 +1,17 @@
+/**
+	{
+		"api":1,
+		"name":"Replace Smart Quotes",
+		"description":"Replace Smart Quotes with their simpler values.",
+		"author":"Thomas Bauer (https://github.com/tbauer428)",
+		"icon":"broom",
+        "tags":"smart,quotes,quotations,quotation,smart-quotes,smart-quotations"
+	}
+**/
+
+function main(input) {
+  input.text = input.text
+    .replace(/[\u2018\u2019]/g, "'")
+    .replace(/[\u201C\u201D]/g, '"')
+    .replace(/“”/g, '"');
+}


### PR DESCRIPTION
The team I work on loves Boop!  We also have a strong disdain for “smart quotes”, so I wrote a script that uses regex to replace the “smart quotes” with their simpler variations (", ').  This helps if you are getting sent snippets of code that are being formatted by things like Slack (and assuming they also don't use a code block or snippet format).

![Screen Recording 2020-08-31 at 6 02 40 PM](https://user-images.githubusercontent.com/30061026/91777172-bdd95900-ebb4-11ea-825c-d02021b6fd0a.gif)
