### PR TITLE
split out the tags into separate FuseProperty objects with the same weight

### DIFF
--- a/Boop/Boop/System/Models/Script.swift
+++ b/Boop/Boop/System/Models/Script.swift
@@ -42,7 +42,7 @@ class Script: NSObject {
     var info:[String: Any]
     
     var name: String?
-    var tags: String?
+    var tags: [String]
     var desc: String?
     var icon: String?
     var bias: Double?
@@ -58,7 +58,7 @@ class Script: NSObject {
         self.isBuiltInt = builtIn
         
         self.name = parameters["name"] as? String
-        self.tags = parameters["tags"] as? String
+        self.tags = Script.parseTerms(terms: parameters["tags"] as? String)
         self.desc = parameters["description"] as? String
         self.icon = (parameters["icon"] as? String)?.lowercased()
         self.bias = parameters["bias"] as? Double
@@ -83,6 +83,10 @@ class Script: NSObject {
         main.call(withArguments: [execution])
     }
     
+    private static func parseTerms(terms: String?) -> [String] {
+        // reurn either an empty array or the terms split by comma space or semicolon
+        terms?.components(separatedBy: CharacterSet(charactersIn: ",; ")) ?? [String]()
+    }
 }
 
 extension Script: Fuseable {
@@ -90,9 +94,9 @@ extension Script: Fuseable {
     var properties: [FuseProperty] {
         return [
             FuseProperty(value: name, weight: 0.9),
-            FuseProperty(value: tags, weight: 0.6),
             FuseProperty(value: desc, weight: 0.2)
-        ]
+        ] + tags.map({(tag: String) -> FuseProperty in
+            FuseProperty(value: tag, weight: 0.6)})
     }
 }
 


### PR DESCRIPTION
When I put together #166 (thanks for merging BTW!) I hadn't noticed the `Collapse.js` script, though I had searched for "join" which is one of the tags on that script. Maybe it's partly because it's last in the list?

This seems to fix search by any tag, even if it's later in a long list.