### PR TITLE
clear statusView before script execution

### DIFF
--- a/Boop/Boop/System/ScriptManager.swift
+++ b/Boop/Boop/System/ScriptManager.swift
@@ -221,6 +221,7 @@ class ScriptManager: NSObject {
     func runScript(_ script: Script, selection: String? = nil, fullText: String, insertIndex: Int? = nil) -> String {
         let scriptExecution = ScriptExecution(selection: selection, fullText: fullText, script: script, insertIndex: insertIndex)
         
+        self.statusView.setStatus(.normal)
         script.run(with: scriptExecution)
         
         return scriptExecution.text ?? ""


### PR DESCRIPTION
If the status field still contains info or error from the previous script run, it won't be relevant after running a new script, so the previous status should be immediately evicted.

Fixes #179 