### PR TITLE
Added csv, tsv or markdown table to "pretty markdown table" Script

### DIFF
--- a/Scripts/convertToMarkdownTable.js
+++ b/Scripts/convertToMarkdownTable.js
@@ -24,6 +24,7 @@ function convertToPrettyMarkdownTableFormat(input) {
     let length = 0;
     for (let i = 0; i < character.length; i++) {
       const c = character.charCodeAt(i);
+      // Multibyte handling
       (c >= 0x0 && c < 0x81) || (c === 0xf8f0) || (c >= 0xff61 && c < 0xffa0) || (c >= 0xf8f1 && c < 0xf8f4) ? length += 1 : length += 2;
     }
     return length;

--- a/Scripts/convertToMarkdownTable.js
+++ b/Scripts/convertToMarkdownTable.js
@@ -1,0 +1,47 @@
+/**
+	{
+		"api":1,
+		"name":"Convert to pretty markdown table",
+		"description":"Converts csv, tsv or markdown table into pretty markdown table format.",
+		"author":"xshoji",
+		"icon":"term",
+		"tags":"csv,tsv,md,markdown"
+	}
+**/
+function main(input) {
+  input.text = convertToPrettyMarkdownTableFormat(input.text);
+}
+
+function convertToPrettyMarkdownTableFormat(input) {
+  const list = input.trim().replace(/^(\r?\n)+$/g, "\n").split("\n").map(v => v.replace(/^\||\|$/g, ""));
+  const delimiter = [`|`, `\t`, `","`, `,`].find(v => list[0].split(v).length > 1);
+  if (delimiter === `|`) {
+    // If input text is markdown table format, removes header separator.
+    list.splice(1, 1);
+  }
+  const tableElements = list.map(record => record.split(delimiter).map(v => v.trim()));
+  const calcBytes = (character) => {
+    let length = 0;
+    for (let i = 0; i < character.length; i++) {
+      const c = character.charCodeAt(i);
+      (c >= 0x0 && c < 0x81) || (c === 0xf8f0) || (c >= 0xff61 && c < 0xffa0) || (c >= 0xf8f1 && c < 0xf8f4) ? length += 1 : length += 2;
+    }
+    return length;
+  };
+  const columnMaxLengthList = tableElements[0].map((v, i) => i).reduce((map, columnIndex) => {
+    let maxLength = 0;
+    tableElements.forEach(record => maxLength < calcBytes(record[columnIndex]) ? maxLength = calcBytes(record[columnIndex]) : null);
+		if (maxLength === 1) {
+			// Avoids markdown header line becomes only ":" ( ":-" is correct. ).
+			maxLength = 2;
+		}
+    map[columnIndex] = maxLength;
+    return map;
+  }, {})
+  const formattedTableElements = tableElements.map(record => record.map((value, columnIndex) => value + "".padEnd(columnMaxLengthList[columnIndex] - calcBytes(value), " ")));
+  const headerValues = formattedTableElements.shift();
+  const tableLine = headerValues.map(v => "".padStart(calcBytes(v), "-").replace(/^./, ":"));
+  formattedTableElements.unshift(tableLine);
+  formattedTableElements.unshift(headerValues);
+  return formattedTableElements.map(record => "| " + record.join(" | ") + " |").join("\n");
+}

--- a/Scripts/convertToMarkdownTable.js
+++ b/Scripts/convertToMarkdownTable.js
@@ -1,12 +1,12 @@
 /**
-	{
-		"api":1,
-		"name":"Convert to pretty markdown table",
-		"description":"Converts csv, tsv or markdown table into pretty markdown table format.",
-		"author":"xshoji",
-		"icon":"term",
-		"tags":"csv,tsv,md,markdown"
-	}
+{
+  "api":1,
+  "name":"Convert to pretty markdown table",
+  "description":"Converts csv, tsv or markdown table into pretty markdown table format.",
+  "author":"xshoji",
+  "icon":"term",
+  "tags":"csv,tsv,md,markdown"
+}
 **/
 function main(input) {
   input.text = convertToPrettyMarkdownTableFormat(input.text);
@@ -31,10 +31,10 @@ function convertToPrettyMarkdownTableFormat(input) {
   const columnMaxLengthList = tableElements[0].map((v, i) => i).reduce((map, columnIndex) => {
     let maxLength = 0;
     tableElements.forEach(record => maxLength < calcBytes(record[columnIndex]) ? maxLength = calcBytes(record[columnIndex]) : null);
-		if (maxLength === 1) {
-			// Avoids markdown header line becomes only ":" ( ":-" is correct. ).
-			maxLength = 2;
-		}
+    if (maxLength === 1) {
+      // Avoids markdown header line becomes only ":" ( ":-" is correct. ).
+      maxLength = 2;
+    }
     map[columnIndex] = maxLength;
     return map;
   }, {})


### PR DESCRIPTION
I am apologize sudden pull request.
( If issue is required, I will create it. )

Can I add this feature?
This script execution image as follows.

```bash
# csv to markdown table
$ echo -e "a,bbb,c\nddd,e,fff"
a,bbb,c
ddd,e,fff
$ echo -e "a,bbb,c\nddd,e,fff" |node convertToMarkdownTable.js
| a   | bbb | c   |
| :-- | :-- | :-- |
| ddd | e   | fff |

# tsv to markdown table
$ echo -e "a\tbbb\tc\nddd\te\tfff"
a	bbb	c
ddd	e	fff
$ echo -e "a\tbbb\tc\nddd\te\tfff" |node convertToMarkdownTable.js
| a   | bbb | c   |
| :-- | :-- | :-- |
| ddd | e   | fff |

# markdown table to pretty markdown table
$ echo -e "|a|bbb|c|\n|:-|:-|:-|\n|ddd|e|fff|"
|a|bbb|c|
|:-|:-|:-|
|ddd|e|fff|
$ echo -e "|a|bbb|c|\n|:-|:-|:-|\n|ddd|e|fff|" |node convertToMarkdownTable.js
| a   | bbb | c   |
| :-- | :-- | :-- |
| ddd | e   | fff |

```