### PR TITLE
Add script to convert JS arrays/objects to PHP associative array.

### DIFF
--- a/Scripts/jsToPhp.js
+++ b/Scripts/jsToPhp.js
@@ -30,8 +30,6 @@ const toPHP = function (value, indentation) {
       value = value.replace(/"/g, '\\"');
       value = `"${value}"`;
       break;
-    default:
-      value = value;
   }
 
   return value;

--- a/Scripts/jsToPhp.js
+++ b/Scripts/jsToPhp.js
@@ -1,0 +1,51 @@
+/**
+	{
+		"api":1,
+		"name":"JS To PHP",
+		"description":"Convert JS Object or Array to PHP.",
+		"author":"jtolj",
+		"icon":"elephant",
+		"tags":"js,php,convert"
+	}
+**/
+
+function main(state) {
+  try {
+    if (!state.text.match(/(\{|\[).*(\}|\])(;)?/s)) {
+      throw new Error('Could not parse as JS Array or Object.');
+    }
+    const result = new Function(`return ${state.text}`)();
+    state.text = convert(result) + ';';
+  } catch (error) {
+    state.postError(error.message);
+  }
+}
+
+const toPHP = function (value, indentation) {
+  switch (typeof value) {
+    case 'object':
+      value = convert(value, indentation + 1);
+      break;
+    case 'string':
+      value = value.replace(/"/g, '\\"');
+      value = `"${value}"`;
+      break;
+    default:
+      value = value;
+  }
+
+  return value;
+};
+
+const convert = function (result, indentation = 1) {
+  const isArray = Array.isArray(result);
+  let str = Object.keys(result).reduce((acc, key) => {
+    const value = toPHP(result[key], indentation);
+    acc += ' '.repeat(indentation * 4);
+    acc += isArray ? value : `'${key}' => ${value}`;
+    acc += ',\n';
+    return acc;
+  }, '');
+  const endingIndentation = ' '.repeat((indentation - 1) * 4);
+  return `[\n${str}${endingIndentation}]`;
+};

--- a/Scripts/jsToPhp.js
+++ b/Scripts/jsToPhp.js
@@ -10,16 +10,22 @@
 **/
 
 function main(state) {
+  const js = state.text.replace(/\n\n\/\/ Result:[\s\S]*$/, '');
+  let output = '';
   try {
-    const result = new Function(`return ${state.text}`)();
-    state.text = convert(result) + ';';
+    const result = new Function(`return ${js}`)();
+    output = convert(result) + ';';
   } catch (error) {
     state.postError(error.message);
   }
+  state.text = js + "\n\n// Result:\n\n" + output;
 }
 
 const toPHP = function (value, indentation) {
   switch (typeof value) {
+    case 'undefined':
+      value = null;
+      break;
     case 'object':
       if(value !== null) {
         value = convert(value, indentation + 1);

--- a/Scripts/jsToPhp.js
+++ b/Scripts/jsToPhp.js
@@ -11,9 +11,6 @@
 
 function main(state) {
   try {
-    if (!state.text.match(/(\{|\[).*(\}|\])(;)?/s)) {
-      throw new Error('Could not parse as JS Array or Object.');
-    }
     const result = new Function(`return ${state.text}`)();
     state.text = convert(result) + ';';
   } catch (error) {

--- a/Scripts/jsToPhp.js
+++ b/Scripts/jsToPhp.js
@@ -21,7 +21,9 @@ function main(state) {
 const toPHP = function (value, indentation) {
   switch (typeof value) {
     case 'object':
-      value = convert(value, indentation + 1);
+      if(value !== null) {
+        value = convert(value, indentation + 1);
+      }
       break;
     case 'string':
       value = value.replace(/"/g, '\\"');


### PR DESCRIPTION
I find myself needing to do this pretty often, so knocked together this script and thought I'd share.

Converts JS array to a flat PHP array [1,2,"3"] to [1,2,"3"].

Converts JS object to PHP associative array {a: 1, b: "2"} to ['a' => 1, 'b' => '2'].

Should work fine with arbitrarily deep nesting of arrays or objects.

Thanks for Boop!

PS - 
Don't think there's a good way to do this without eval() or new Function()
