### PR TITLE
Show popover on status view click

### DIFF
--- a/Boop/Boop/Controllers/PopoverViewController.swift
+++ b/Boop/Boop/Controllers/PopoverViewController.swift
@@ -32,6 +32,11 @@ class PopoverViewController: NSViewController {
         // Double-click script selection
         tableView.doubleAction = #selector(runSelectedScript)
 
+        // Show popover on status view click
+        statusView.onMouseDown = { [weak self] in
+            self?.show()
+        }
+
         // Dismiss popover on background view click
         overlayView.onMouseDown = { [weak self] in
             self?.hide()

--- a/Boop/Boop/Views/StatusView.swift
+++ b/Boop/Boop/Views/StatusView.swift
@@ -40,7 +40,12 @@ class StatusView: NSView {
         self.layer?.cornerRadius = 5
         
     }
-
+    
+    var onMouseDown: (() -> Void)?
+    override func mouseDown(with event: NSEvent) {
+        onMouseDown?()
+    }
+    
     func setStatus(_ newStatus: Status) {
         
         switch newStatus {


### PR DESCRIPTION
I found myself repeatedly clicking the status button to open the script picker using the mouse as opposed to only being able to open it via ⌘-B or the menu. This PR just implements a mouseDown handler on the toolbar object that opens the popover list as done by the menu item. The behavior seems intuitive, especially if you're mousing around already.