### PR TITLE
Fix undefined error in FullURLDecode

### DIFF
--- a/Scripts/FullURLDecode.js
+++ b/Scripts/FullURLDecode.js
@@ -15,7 +15,7 @@ function fullUrlDecode(str) {
 	var decoded = '';
 
 	for (var i = 0; i < codes.length; i++) {
-		decoded += String.fromCharCode(parseInt(c, 16));
+		decoded += String.fromCharCode(parseInt(codes[i], 16));
 	}
 
 	return decoded;


### PR DESCRIPTION
`FullURLDecode.js` doesn't work since `c` was undefined, this PR resolves this issue. 

Having played with it a little I am unsure if the script is even necessary. @luisfontes19, do you have an example where the behavior of your script differs from the existing `URLDecode.js` script?