### PR TITLE
Adding 2-way temp conversion scripts: Cº to Fº and Fº to Cº 

### DIFF
--- a/Scripts/CtoF.js
+++ b/Scripts/CtoF.js
@@ -1,0 +1,17 @@
+/**
+	{
+		"api":1,
+		"name":"Centigrade to Farenheit",
+		"description":"Convert temp from ºC to ºF.",
+		"author":"armchairdeity",
+		"icon":"translation",
+		"tags":"join"
+	}
+**/
+
+function main(state) {
+	let foo = parseFloat(state.fullText);
+	(foo != "NaN") ?
+		state.fullText = `${foo}°C = ${(((foo*9)/5)+32).toFixed(2)}°F` :
+		state.fullText = "Please enter a number to be converted to Centigrade.";
+}

--- a/Scripts/CtoF.js
+++ b/Scripts/CtoF.js
@@ -11,7 +11,7 @@
 
 function main(state) {
 	let foo = parseFloat(state.fullText);
-	(foo != "NaN") ?
+	foo ?
 		state.fullText = `${foo}°C = ${(((foo*9)/5)+32).toFixed(2)}°F` :
 		state.fullText = "Please enter a number to be converted to Centigrade.";
 }

--- a/Scripts/FtoC.js
+++ b/Scripts/FtoC.js
@@ -1,0 +1,17 @@
+/**
+	{
+		"api":1,
+		"name":"Farenheit to Centigrade",
+		"description":"Convert temp from ºF to ºC.",
+		"author":"armchairdeity",
+		"icon":"translation",
+		"tags":"join"
+	}
+**/
+
+function main(state) {
+	let foo = parseFloat(state.fullText);
+	foo ?
+		state.text = `${foo}°F = ${(((foo-32)*5)/9).toFixed(2)}°C` :
+		state.fullText = "Please enter a number to be converted to Centigrade.";
+}


### PR DESCRIPTION
I find myself using Boop more and more and since it's the easiest way to just SLAM run a fast script on a value... it seemed like being able to type a number and from the same interface be able to see the number you typed converted from F to C or C to F. This is especially useful for quick and dirty conversions for things like blog posts and social media posts.

Each is a separate script, and currently I find I can use such limited keystrokes to be able to run this. It's awesome:

- Convert from C to F: `<number> <cmd-B> ce <enter>`
- Convert from F to C: `<number> <cmd-B> fa <enter>`

It checks to make sure that the incoming value is a `float` and displays a friendly error if not.