### PR TITLE
Supporting SF Symbols identifiers for script icons

### DIFF
--- a/Boop/Boop/Controllers/ScriptsTableViewController.swift
+++ b/Boop/Boop/Controllers/ScriptsTableViewController.swift
@@ -22,6 +22,20 @@ class ScriptsTableViewController: NSViewController, NSTableViewDelegate, NSTable
         return results.count
     }
     
+    private func scriptIcon(identifier: String?) -> NSImage? {
+        guard let identifier = identifier else {
+            return NSImage(named: "icons8-unknown")
+        }
+        if let namedImage = NSImage(named: "icons8-\(identifier)") {
+            return namedImage
+        }
+        if #available(macOS 11.0, *),
+           let systemImage = NSImage(systemSymbolName: identifier, accessibilityDescription: nil) {
+            return systemImage
+        }
+        return nil
+    }
+    
     func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {        
         
         let view = tableView.makeView(withIdentifier: NSUserInterfaceItemIdentifier(rawValue: "scriptCell"), owner: self) as! ScriptTableViewCell
@@ -33,7 +47,7 @@ class ScriptsTableViewController: NSViewController, NSTableViewDelegate, NSTable
         view.titleLabel.stringValue = script.name ?? "No Name 🤔"
         view.subtitleLabel.stringValue = script.desc ?? "No Description 😢"
         
-        view.imageView?.image = NSImage(named: "icons8-\(script.icon ?? "unknown")")
+        view.imageView?.image = self.scriptIcon(identifier: script.icon)
         
         return view
         

--- a/Boop/Documentation/CustomScripts.md
+++ b/Boop/Documentation/CustomScripts.md
@@ -29,7 +29,7 @@ Each script starts with a declarative JSON document, describing the contents of 
 
 * `api` is not currently used, but is strongly recommended for potential backwards compatibility. You should set it to 1.
 * `name`, `description` and `author` are exactly what you think they are.
-* `icon` is a visual representation of your scripts' actions. You can see available icons in `Boop/Assets.xcassets/Icons/`. If you can't find what you like, feel free to create an issue and we'll make it work!
+* `icon` is a visual representation of your scripts' actions. You can see available icons in `Boop/Assets.xcassets/Icons/`. On macOS 11 and above you can also use [SF Symbols](https://developer.apple.com/sf-symbols/). If you can't find what you like, feel free to create an issue and we'll make it work!
 * `tags` are used by the fuzzy-search algorythm to filter and sort results.
 
 An optional property, `bias`, can also be added to help Boop prioritize your scripts. A positive value will move your script higher in the results, a negative value will push it further down. The bias property is a number:


### PR DESCRIPTION
Just a small change that also supports SF Symbols identifiers as script icon names:
* For compatibility purposes, images in the Asset catalog take precedence.
* If an appropriate image hasn't been found there, Boop tries to get the SF Symbol using `NSImage(systemSymbolName:accessibilityDescription:)` (only on macOS 11+).
* If a script specifies an icon but nothing with the appropriate name can be found, then the icon is `nil`
* If a script does not specify an icon, then the icon defaults to `icons8-unknown`, just as it does previously

I did not change the `.lowercased()` in the initialisation of Script since SF Symbols also uses lowercase-only identifiers.

The documentation has been updated appropriately.

### Overview of the new functionality

![script-with-sfsymbol-identifier](https://user-images.githubusercontent.com/8214480/124251152-e3612700-db25-11eb-924f-085e3ffec34a.png)
Specifiying an SF Symbol name in a script

![boop-ui-with-sfsymbol](https://user-images.githubusercontent.com/8214480/124251162-e6f4ae00-db25-11eb-9bdf-c454d103ac06.png)
Selection

