### PR TITLE
Timestamp to ISO Date

### DIFF
--- a/Scripts/UnixTimeToDate.js
+++ b/Scripts/UnixTimeToDate.js
@@ -1,0 +1,26 @@
+/**
+	{
+		"api":1,
+		"name":"Timestamp to Date(ISO)",
+		"description":"Converts a unix timestamp to a ISO Date string",
+		"author":"riesentoaster",
+		"icon":"collapse",
+		"tags":"join, space",
+		"bias": -0.1
+	}
+**/
+
+function main(input) {
+    input.text = input.text.trim();
+    if (input.text.match(/^\d+$/)) {
+        if (input.text.length == 13) {
+            input.text = new Date(Number(input.text)).toISOString();
+        } else if (input.text.length == 10) {
+            input.text = new Date(Number(input.text)*1000).toISOString();
+        } else {
+            input.postError('Invalid timestamp (not 10 or 13 characters long)');
+        }
+    } else {
+        input.postError('Invalid timestamp (not a number)');
+    }
+}


### PR DESCRIPTION
To address https://github.com/IvanMathy/Boop/issues/280

Supports timestamps in both seconds (10 numbers) or milliseconds (13 numbers)


Input:
```
1625842985835
```

Output:
```
2021-07-09T15:03:05.835Z
```