### PR TITLE
Create Stringify.js

### DIFF
--- a/Scripts/Stringify.js
+++ b/Scripts/Stringify.js
@@ -1,0 +1,13 @@
+/**
+{
+  "api": 1,
+  "name": "Stringify JSON",
+  "description": "Stringify JSON to a single line",
+  "author": "rcalixte",
+  "icon": "type",
+  "tags": "convert,stringify,json"
+}
+**/
+function main(input) { 
+  input.text = JSON.stringify(input.text.replace(/\n\s*/g, ''));
+} 


### PR DESCRIPTION
Adds a script to run JSON.stringify() over input but that Boop returns a usable JSON string object.

Example input:
```json
{
  "json": [
    "abc",
    "def"
  ]
}
```
returns:
```javascript
"{\"json\": [\"abc\",\"def\"]}"
```