### PR TITLE
Sort should ignore whitespace

### DIFF
--- a/Boop/Boop/scripts/Sort.js
+++ b/Boop/Boop/scripts/Sort.js
@@ -11,7 +11,11 @@
 
 function main(input) {
     let sorted = input.text.replace(/\n$/, '').split('\n')
-        .sort((a, b) => a.localeCompare(b))
+        .sort((a, b) => {
+            a = a.replace(/^\s+/, '');
+            b = b.replace(/^\s+/, '');
+            return a.localeCompare(b);
+        })
         .join('\n');
 
     if (sorted === input.text) {


### PR DESCRIPTION
Sort should ignore whitespace at the start of each line during comparison. This allows for lists/code with abitrary formatting to be sorted correctly and still maintain formatting.