### PR TITLE
Basic open/save functionality

### DIFF
--- a/Boop/Boop/AppDelegate.swift
+++ b/Boop/Boop/AppDelegate.swift
@@ -17,6 +17,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @IBOutlet weak var closePickerMenuItem: NSMenuItem!
     
     @IBOutlet weak var popoverViewController: PopoverViewController!
+    @IBOutlet weak var mainViewController: MainViewController!
     @IBOutlet weak var scriptManager: ScriptManager!
     @IBOutlet weak var editor: SyntaxTextView!
 
@@ -39,6 +40,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        return true
+    }
+
+    func application(_ sender: NSApplication, openFile filename: String) -> Bool {
+            
+        let text=try? String(contentsOf: URL(fileURLWithPath: filename))
+        mainViewController.setText(text ?? "Failed to load: " + filename)
         return true
     }
 

--- a/Boop/Boop/Boop.entitlements
+++ b/Boop/Boop/Boop.entitlements
@@ -6,7 +6,7 @@
 	<true/>
 	<key>com.apple.security.files.bookmarks.app-scope</key>
 	<true/>
-	<key>com.apple.security.files.user-selected.read-only</key>
+	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>

--- a/Boop/Boop/BoopRelease.entitlements
+++ b/Boop/Boop/BoopRelease.entitlements
@@ -6,7 +6,7 @@
 	<true/>
 	<key>com.apple.security.files.bookmarks.app-scope</key>
 	<true/>
-	<key>com.apple.security.files.user-selected.read-only</key>
+	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>

--- a/Boop/Boop/Controllers/MainViewController.swift
+++ b/Boop/Boop/Controllers/MainViewController.swift
@@ -72,7 +72,7 @@ class MainViewController: NSViewController {
         updateBuddy.check()
     }
 
-    @IBAction func browseFile(sender: AnyObject) {
+    @IBAction func openFile(sender: AnyObject) {
         
         let dialog = NSOpenPanel();
         
@@ -84,10 +84,35 @@ class MainViewController: NSViewController {
         dialog.allowsMultipleSelection = false;
 
         if (dialog.runModal() == NSApplication.ModalResponse.OK) {
-            if let result = dialog.url { // Pathname of the file
-                let path = result.path
-                let text=try? String(contentsOf: URL(fileURLWithPath: path))
-                setText(text ?? "Failed to load: " + path)
+            if let pathUrl = dialog.url { // Pathname of the file
+                let text=try? String(contentsOf: pathUrl)
+                setText(text ?? "Failed to load file '\(pathUrl.path)'.")
+            }
+        }
+        
+    }
+    
+    @IBAction func saveFileAs(sender: AnyObject) {
+        
+        let dialog = NSSavePanel();
+        
+        dialog.title                   = "Save content as…";
+        dialog.showsResizeIndicator    = true;
+        dialog.showsHiddenFiles        = false;
+        dialog.showsTagField           = false;
+        dialog.canCreateDirectories    = true;
+        dialog.nameFieldStringValue    = "Untitled.txt"
+
+        if (dialog.runModal() == NSApplication.ModalResponse.OK) {
+            if let pathUrl = dialog.url { // Pathname of the file
+                let textView = editorView.contentTextView
+                let textData=textView.textStorage?.string.data(using: .utf8)
+                do {
+                    try textData?.write(to: pathUrl)
+                } catch let error as NSError {
+                    setText("Failed to save content to file '\(pathUrl.path)'. (Reason: \(error.localizedFailureReason!))")
+                    // TODO: Show error in alert box
+                }
             }
         }
         

--- a/Boop/Boop/Controllers/MainViewController.swift
+++ b/Boop/Boop/Controllers/MainViewController.swift
@@ -48,25 +48,51 @@ class MainViewController: NSViewController {
     }
     
     @IBAction func clear(_ sender: Any) {
+        setText("")
+    }
+    
+    public func setText(_ text: String) {
         let textView = editorView.contentTextView
         textView.textStorage?.beginEditing()
         
         let range = NSRange(location: 0, length: textView.textStorage?.length ?? textView.string.count)
         
-        guard textView.shouldChangeText(in: range, replacementString: "") else {
+        guard textView.shouldChangeText(in: range, replacementString: text) else {
             return
         }
         
-        textView.textStorage?.replaceCharacters(in: range, with: "")
+        textView.textStorage?.replaceCharacters(in: range, with: text)
         
         textView.textStorage?.endEditing()
         textView.didChangeText()
     }
     
-    
+
     @IBAction func checkForUpdates(_ sender: Any) {
         updateBuddy.check()
     }
+
+    @IBAction func browseFile(sender: AnyObject) {
+        
+        let dialog = NSOpenPanel();
+        
+        dialog.title                   = "Choose a file";
+        dialog.showsResizeIndicator    = true;
+        dialog.showsHiddenFiles        = false;
+        dialog.canChooseDirectories    = false;
+        dialog.canCreateDirectories    = false;
+        dialog.allowsMultipleSelection = false;
+
+        if (dialog.runModal() == NSApplication.ModalResponse.OK) {
+            if let result = dialog.url { // Pathname of the file
+                let path = result.path
+                let text=try? String(contentsOf: URL(fileURLWithPath: path))
+                setText(text ?? "Failed to load: " + path)
+            }
+        }
+        
+    }
+    
 }
 
 extension MainViewController: SyntaxTextViewDelegate {

--- a/Boop/Boop/Info.plist
+++ b/Boop/Boop/Info.plist
@@ -53,5 +53,16 @@
 			</array>
 		</dict>
 	</array>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>*</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/Boop/UI/Base.lproj/MainMenu.xib
+++ b/Boop/UI/Base.lproj/MainMenu.xib
@@ -55,6 +55,7 @@
             <connections>
                 <outlet property="closePickerMenuItem" destination="KYm-JI-9g0" id="aZo-Hy-RkG"/>
                 <outlet property="editor" destination="Ef0-Na-xwu" id="rks-Mp-ffh"/>
+                <outlet property="mainViewController" destination="unv-pE-gme" id="SJf-P6-FHE"/>
                 <outlet property="openPickerMenuItem" destination="8ka-cp-srR" id="qZt-zg-2wc"/>
                 <outlet property="popoverViewController" destination="ugb-uZ-HP1" id="gLb-EK-85g"/>
                 <outlet property="scriptManager" destination="jdF-I6-2al" id="o2F-Lj-Vou"/>
@@ -128,9 +129,9 @@
                                     <action selector="clear:" target="unv-pE-gme" id="Mj1-40-053"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Open…" hidden="YES" keyEquivalent="o" id="IAo-SY-fd9">
+                            <menuItem title="Open…" keyEquivalent="o" id="IAo-SY-fd9">
                                 <connections>
-                                    <action selector="openDocument:" target="-1" id="bVn-NM-KNZ"/>
+                                    <action selector="browseFileWithSender:" target="unv-pE-gme" id="KxG-Xy-LeB"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Open Recent" hidden="YES" id="tXI-mr-wws">

--- a/Boop/UI/Base.lproj/MainMenu.xib
+++ b/Boop/UI/Base.lproj/MainMenu.xib
@@ -131,7 +131,7 @@
                             </menuItem>
                             <menuItem title="Open…" keyEquivalent="o" id="IAo-SY-fd9">
                                 <connections>
-                                    <action selector="browseFileWithSender:" target="unv-pE-gme" id="KxG-Xy-LeB"/>
+                                    <action selector="openFileWithSender:" target="unv-pE-gme" id="l3F-jU-eYg"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Open Recent" hidden="YES" id="tXI-mr-wws">
@@ -148,19 +148,15 @@
                                 </menu>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="m54-Is-iLE"/>
-                            <menuItem title="Close" keyEquivalent="w" id="DVo-aG-piG">
-                                <connections>
-                                    <action selector="performClose:" target="-1" id="HmO-Ls-i7Q"/>
-                                </connections>
-                            </menuItem>
-                            <menuItem title="Save…" hidden="YES" keyEquivalent="s" id="pxx-59-PXV">
+                            <menuItem title="Save…" hidden="YES" id="pxx-59-PXV">
+                                <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="saveDocument:" target="-1" id="teZ-XB-qJY"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Save As…" hidden="YES" keyEquivalent="S" id="Bw7-FT-i3A">
+                            <menuItem title="Save As…" keyEquivalent="s" id="Bw7-FT-i3A">
                                 <connections>
-                                    <action selector="saveDocumentAs:" target="-1" id="mDf-zr-I0C"/>
+                                    <action selector="saveFileAsSender:" target="unv-pE-gme" id="vLF-0s-Nt1"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Revert to Saved" hidden="YES" keyEquivalent="r" id="KaW-ft-85H">
@@ -178,6 +174,11 @@
                             <menuItem title="Print…" hidden="YES" keyEquivalent="p" id="aTl-1u-JFS">
                                 <connections>
                                     <action selector="print:" target="-1" id="qaZ-4w-aoO"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Close" keyEquivalent="w" id="DVo-aG-piG">
+                                <connections>
+                                    <action selector="performClose:" target="-1" id="HmO-Ls-i7Q"/>
                                 </connections>
                             </menuItem>
                         </items>


### PR DESCRIPTION
With this merge request I propose basic file handling functionality. Open any file type and _try_ to parse it as String via `String(contentsOf: pathUrl)` – silently ignore the file if it cannot be parsed. This works also via `CMD+O` and by dragging the file on the app icon.
This addresses #256 and #227.

Save the content as file (via `CMD+S`). There is no notion of an open file, it's always "Save As…".
This addresses #278.
