### PR TITLE
Add support for 0b notation

### DIFF
--- a/Boop/Boop/scripts/BinaryToDecimal.js
+++ b/Boop/Boop/scripts/BinaryToDecimal.js
@@ -16,6 +16,7 @@ function main(state) {
 
   for (const index in lines) {
     var text = lines[index].trim();
+    if (text.startsWith("0b")) text = text.split("0b").pop();
     var decimal = parseInt(text, 2);
 
     if (isNaN(decimal)) {


### PR DESCRIPTION
Currently, if a binary string formatted with 0b is inputted, it will resolve to zero since it only cares about the first numerical character in the line. This change will detect if 0b is at the head and if so, will cut it off.

This is the only place I noticed this lacking, if this needs to be added anywhere else please feel free to append to this.

Thank you, Eldon.