### PR TITLE
Open scripts folder

### DIFF
--- a/Boop/Boop/Controllers/MainViewController.swift
+++ b/Boop/Boop/Controllers/MainViewController.swift
@@ -38,6 +38,22 @@ class MainViewController: NSViewController {
         open(url: "https://boop.okat.best/scripts/")
     }
     
+    @IBAction func openScriptsFolder(_ sender: Any) {
+        do {
+            
+            guard let url = try ScriptManager.getBookmarkURL() else {
+//                TODO open preferences so user can pick folder
+                return
+            }
+            
+            NSWorkspace.shared.open(url)
+            
+        }
+        catch let error {
+            print(error)
+            return
+        }
+    }
     
     func open(url: String) {
         guard let url = URL(string: url) else {

--- a/Boop/Boop/Controllers/MainViewController.swift
+++ b/Boop/Boop/Controllers/MainViewController.swift
@@ -42,7 +42,8 @@ class MainViewController: NSViewController {
         do {
             
             guard let url = try ScriptManager.getBookmarkURL() else {
-//                TODO open preferences so user can pick folder
+                let controller = NSStoryboard.init(name: "Preferences", bundle: nil).instantiateInitialController() as? NSWindowController
+                controller?.showWindow(sender)
                 return
             }
             

--- a/Boop/UI/Base.lproj/MainMenu.xib
+++ b/Boop/UI/Base.lproj/MainMenu.xib
@@ -451,6 +451,11 @@ Gw
                                     <action selector="reloadScripts:" target="Voe-Tx-rLC" id="Rmu-D9-Xm5"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Open Scripts Folder" keyEquivalent="F" id="DIC-Fd-4YF">
+                                <connections>
+                                    <action selector="openScriptsFolder:" target="unv-pE-gme" id="Uap-fp-E5o"/>
+                                </connections>
+                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="Tfr-N1-YjS"/>
                             <menuItem title="Get more scripts…" id="oS5-Vj-4JY">
                                 <modifierMask key="keyEquivalentModifierMask"/>


### PR DESCRIPTION
This PR adds a menu item and keyboard shortcut to open the user scripts folder.

Menu -> Scripts -> Open Scripts Folder
Keyboard shortcut: ⌘+⇧+F (Command + Shift + F)

If the user has not set a scripts folder, this opens the Preferences window so they can choose a folder.

Tested OK locally:
Boop: 1.4.0
OS: macOS Monterey 12.6.1 (M1)

This PR resolves #355 