### PR TITLE
Basic open/save functionality (revised)

### DIFF
--- a/Boop/Boop/AppDelegate.swift
+++ b/Boop/Boop/AppDelegate.swift
@@ -17,8 +17,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @IBOutlet weak var closePickerMenuItem: NSMenuItem!
     
     @IBOutlet weak var popoverViewController: PopoverViewController!
+    @IBOutlet weak var mainViewController: MainViewController!
     @IBOutlet weak var scriptManager: ScriptManager!
     @IBOutlet weak var editor: SyntaxTextView!
+    @IBOutlet weak var statusView: StatusView!
 
     // Frame auto save name for app window frame restoration.
     private static let appWindowName = "boop.app.window"
@@ -42,6 +44,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         return true
     }
 
+    func application(_ sender: NSApplication, openFile filename: String) -> Bool {
+
+        let text=try? String(contentsOf: URL(fileURLWithPath: filename))
+        
+        if text == nil {
+            self.statusView.setStatus(.error("Failed to load file: '\(filename)'."))
+        } else  {
+            editor.text = text!
+        }
+        return true
+    }
+    
     @IBAction func showPreferencesWindow(_ sender: NSMenuItem) {
         let controller = NSStoryboard.init(name: "Preferences", bundle: nil).instantiateInitialController() as? NSWindowController
         

--- a/Boop/Boop/Boop.entitlements
+++ b/Boop/Boop/Boop.entitlements
@@ -10,5 +10,7 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
 </dict>
 </plist>

--- a/Boop/Boop/BoopRelease.entitlements
+++ b/Boop/Boop/BoopRelease.entitlements
@@ -10,5 +10,7 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
 </dict>
 </plist>

--- a/Boop/Boop/Controllers/MainViewController.swift
+++ b/Boop/Boop/Controllers/MainViewController.swift
@@ -10,7 +10,8 @@ import Cocoa
 import SavannaKit
 
 class MainViewController: NSViewController {
-
+    
+    @IBOutlet weak var statusView: StatusView!
     @IBOutlet weak var editorView: SyntaxTextView!
     @IBOutlet weak var updateBuddy: UpdateBuddy!
     @IBOutlet weak var checkUpdateMenuItem: NSMenuItem!
@@ -66,6 +67,54 @@ class MainViewController: NSViewController {
     
     @IBAction func checkForUpdates(_ sender: Any) {
         updateBuddy.check()
+    }
+    
+    @IBAction func openFile(sender: AnyObject) {
+
+        let dialog = NSOpenPanel();
+
+        dialog.title                   = "Choose a file";
+        dialog.showsResizeIndicator    = true;
+        dialog.showsHiddenFiles        = false;
+        dialog.canChooseDirectories    = false;
+        dialog.canCreateDirectories    = false;
+        dialog.allowsMultipleSelection = false;
+
+        if (dialog.runModal() == NSApplication.ModalResponse.OK) {
+            if let pathUrl = dialog.url { // Pathname of the file
+                let text=try? String(contentsOf: pathUrl)
+                
+                if text == nil {
+                    self.statusView.setStatus(.error("Failed to load file: '\(pathUrl.path)'."))
+                } else  {
+                    editorView.text = text!
+                }
+            }
+        }
+    }
+    
+    @IBAction func saveFileAs(sender: AnyObject) {
+        
+        let dialog = NSSavePanel();
+        
+        dialog.title                   = "Save content as…";
+        dialog.showsResizeIndicator    = true;
+        dialog.showsHiddenFiles        = false;
+        dialog.showsTagField           = false;
+        dialog.canCreateDirectories    = true;
+        dialog.nameFieldStringValue    = "Untitled.txt"
+        
+        if (dialog.runModal() == NSApplication.ModalResponse.OK) {
+            if let pathUrl = dialog.url { // Pathname of the file
+                let textView = editorView.contentTextView
+                let textData=textView.textStorage?.string.data(using: .utf8)
+                do {
+                    try textData?.write(to: pathUrl)
+                } catch let error as NSError {
+                    self.statusView.setStatus(.error("Failed to save content to file '\(pathUrl.path)'. (Reason: \(error.localizedFailureReason!))"))
+                }
+            }
+        }
     }
 }
 

--- a/Boop/Boop/Info.plist
+++ b/Boop/Boop/Info.plist
@@ -28,6 +28,17 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>*</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSServices</key>
 	<array>
 		<dict>

--- a/Boop/Boop/System/Models/Script.swift
+++ b/Boop/Boop/System/Models/Script.swift
@@ -97,7 +97,7 @@ extension Script: Fuseable {
     }
 }
 
-protocol ScriptDelegate: class {
+protocol ScriptDelegate: AnyObject {
     func onScriptError(message: String)
     func onScriptInfo(message: String)
 }

--- a/Boop/UI/Base.lproj/MainMenu.xib
+++ b/Boop/UI/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="18122" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="18122"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21701"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -27,6 +27,7 @@
             <connections>
                 <outlet property="checkUpdateMenuItem" destination="mdD-pu-Aba" id="Ffr-2n-BVJ"/>
                 <outlet property="editorView" destination="Ef0-Na-xwu" id="Bgy-ZL-Z2D"/>
+                <outlet property="statusView" destination="zMi-QK-dkF" id="9vO-9b-1jg"/>
                 <outlet property="updateBuddy" destination="twH-mb-iPe" id="Sqq-Ci-vlD"/>
                 <outlet property="view" destination="Ef0-Na-xwu" id="wVq-8C-Rni"/>
             </connections>
@@ -58,6 +59,7 @@
                 <outlet property="openPickerMenuItem" destination="8ka-cp-srR" id="qZt-zg-2wc"/>
                 <outlet property="popoverViewController" destination="ugb-uZ-HP1" id="gLb-EK-85g"/>
                 <outlet property="scriptManager" destination="jdF-I6-2al" id="o2F-Lj-Vou"/>
+                <outlet property="statusView" destination="zMi-QK-dkF" id="Q7F-n7-RCv"/>
                 <outlet property="window" destination="QvC-M9-y7g" id="gIp-Ho-8D9"/>
             </connections>
         </customObject>
@@ -123,14 +125,9 @@
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <menu key="submenu" title="File" id="bib-Uj-vzu">
                         <items>
-                            <menuItem title="Clear" keyEquivalent="n" id="Was-JA-tGl">
+                            <menuItem title="Open…" keyEquivalent="o" id="IAo-SY-fd9">
                                 <connections>
-                                    <action selector="clear:" target="unv-pE-gme" id="Mj1-40-053"/>
-                                </connections>
-                            </menuItem>
-                            <menuItem title="Open…" hidden="YES" keyEquivalent="o" id="IAo-SY-fd9">
-                                <connections>
-                                    <action selector="openDocument:" target="-1" id="bVn-NM-KNZ"/>
+                                    <action selector="openFileWithSender:" target="unv-pE-gme" id="xcF-n8-bT8"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Open Recent" hidden="YES" id="tXI-mr-wws">
@@ -147,19 +144,14 @@
                                 </menu>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="m54-Is-iLE"/>
-                            <menuItem title="Close" keyEquivalent="w" id="DVo-aG-piG">
-                                <connections>
-                                    <action selector="performClose:" target="-1" id="HmO-Ls-i7Q"/>
-                                </connections>
-                            </menuItem>
                             <menuItem title="Save…" hidden="YES" keyEquivalent="s" id="pxx-59-PXV">
                                 <connections>
                                     <action selector="saveDocument:" target="-1" id="teZ-XB-qJY"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Save As…" hidden="YES" keyEquivalent="S" id="Bw7-FT-i3A">
+                            <menuItem title="Save As…" keyEquivalent="S" id="Bw7-FT-i3A">
                                 <connections>
-                                    <action selector="saveDocumentAs:" target="-1" id="mDf-zr-I0C"/>
+                                    <action selector="saveFileAsSender:" target="unv-pE-gme" id="lbR-ze-VhW"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Revert to Saved" hidden="YES" keyEquivalent="r" id="KaW-ft-85H">
@@ -177,6 +169,17 @@
                             <menuItem title="Print…" hidden="YES" keyEquivalent="p" id="aTl-1u-JFS">
                                 <connections>
                                     <action selector="print:" target="-1" id="qaZ-4w-aoO"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="ggp-Jn-CEd"/>
+                            <menuItem title="Clear" keyEquivalent="n" id="Was-JA-tGl">
+                                <connections>
+                                    <action selector="clear:" target="unv-pE-gme" id="Mj1-40-053"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Close" keyEquivalent="w" id="DVo-aG-piG">
+                                <connections>
+                                    <action selector="performClose:" target="-1" id="HmO-Ls-i7Q"/>
                                 </connections>
                             </menuItem>
                         </items>
@@ -509,7 +512,7 @@ Gw
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="335" y="390" width="480" height="360"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="900"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1055"/>
             <value key="minSize" type="size" width="480" height="360"/>
             <view key="contentView" wantsLayer="YES" id="EiT-Mj-1SZ">
                 <rect key="frame" x="0.0" y="0.0" width="480" height="360"/>


### PR DESCRIPTION
Port nobecutan's changes from "Basic open/save functionality" to the latest version of Boop and then make the errors show in the status view.

Original pull request comments:

With this merge request I propose basic file handling functionality. Open any file type and try to parse it as String via String(contentsOf: pathUrl) – silently ignore the file if it cannot be parsed. This works also via CMD+O and by dragging the file on the app icon.
This addresses https://github.com/IvanMathy/Boop/issues/256 and https://github.com/IvanMathy/Boop/issues/227.

Save the content as file (via CMD+SHIFT+S). There is no notion of an open file, it's always "Save As…".
This addresses https://github.com/IvanMathy/Boop/issues/278.