### PR TITLE
TrimCode.js: remove extra indentation

### DIFF
--- a/Scripts/TrimCode.js
+++ b/Scripts/TrimCode.js
@@ -1,0 +1,31 @@
+/**
+{
+  "api": 1,
+  "name": "Trim Code",
+  "description": "Removes extra indentation but keeps original code structure.",
+  "author": "Josh Angelsberg",
+  "icon": "scissors",
+  "tags": "trim,indent,whitespace,code"
+}
+**/
+
+function main(input) {
+  // split into lines
+  const lines = input.text.split('\n');
+  if (!lines.length) return;
+
+  // trim leading whitespace on the first line
+  const firstLine = lines[0];
+  const trimmedFirst = firstLine.trimStart();
+  const indentCount = firstLine.length - trimmedFirst.length;
+
+  // apply the same slice to every line
+  const result = lines.map((line, idx) =>
+    idx === 0
+      ? trimmedFirst
+      : line.slice(indentCount)
+  );
+
+  // rejoin and update
+  input.text = result.join('\n');
+}


### PR DESCRIPTION
Hey all!

This adds a nifty little script called 'TrimCode.js' - where it removes extra indentation but keeps original code structure.

<img width="720" height="682" alt="483447725-8ff48c05-5d30-4878-b319-6682875227cf" src="https://github.com/user-attachments/assets/67f842e8-7dbf-4bea-bbea-d389fef84e7b" />

(Also the screenshot above is from my [Boop for Alfred workflow](https://github.com/jangelsb/boop-for-alfred-workflow) - where I recreated the Boop engine to run inside Alfred)

Happy Booping!
